### PR TITLE
Use environ instead of __environ

### DIFF
--- a/catatonit.c
+++ b/catatonit.c
@@ -216,7 +216,7 @@ static int spawn_pid1(char *file, char **argv, sigset_t *sigmask)
 	if (sigprocmask(SIG_SETMASK, sigmask, NULL) < 0)
 		bail("failed to reset sigmask: %m");
 
-	execvpe(file, argv, __environ);
+	execvpe(file, argv, environ);
 	bail("failed to exec pid1: %m");
 }
 


### PR DESCRIPTION
Fixes compilation with musl.

catatonit currently fails to compile with musl because it uses the internal `__environ` variable which is not defined in musl's `unistd.h`:

```
catatonit.c: In function 'spawn_pid1':
catatonit.c:216:22: error: '__environ' undeclared (first use in this function); did you mean 'environ'?
  216 |  execvpe(file, argv, __environ);
      |                      ^~~~~~~~~
      |                      environ
```

This variable is also not mentioned in the glibc's documentation and should probably not be used. Changed it to the documented [`environ` variable](https://www.gnu.org/software/libc/manual/html_node/Environment-Access.html#index-environ), which is also [supported by musl](https://github.com/esmil/musl/blob/194f9cf93da8ae62491b7386edf481ea8565ae4e/include/unistd.h#L182) with `_GNU_SOURCE`. With this PR, catatonit compiles successfully with both glibc and musl.