### PR TITLE
fix build with kernel < 5.9

### DIFF
--- a/catatonit.c
+++ b/catatonit.c
@@ -36,7 +36,7 @@
 #include <limits.h>
 #include <dirent.h>
 
-#ifdef HAVE_CLOSE_RANGE
+#ifdef HAVE_LINUX_CLOSE_RANGE_H
 # include <linux/close_range.h>
 #else
 # include <sys/syscall.h>

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ LT_PREREQ([2.4.2])
 LT_INIT([disable-shared])
 
 AC_CHECK_HEADERS([errno.h fcntl.h signal.h stdarg.h stdio.h stdlib.h unistd.h])
-AC_CHECK_HEADERS([sys/prctl.h sys/signalfd.h sys/stat.h sys/types.h sys/wait.h])
+AC_CHECK_HEADERS([linux/close_range.h sys/prctl.h sys/signalfd.h sys/stat.h sys/types.h sys/wait.h])
 
 AC_CHECK_FUNCS([close_range])
 


### PR DESCRIPTION
`linux/close_range.h` is only available since kernel 5.9 and https://github.com/torvalds/linux/commit/60997c3d45d9a67daf01c56d805ae4fec37e0bd8 resulting in the following build failure:

```
catatonit.c:39:11: fatal error: linux/close_range.h: No such file or directory
   39 | # include <linux/close_range.h>
      |           ^~~~~~~~~~~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/ed9a847905083175c7fcb2f2df28f9ac5b9c3313

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>