### PR TITLE
catatonit: fix format specifier for long long fd value

### DIFF
--- a/catatonit.c
+++ b/catatonit.c
@@ -230,7 +230,7 @@ static int close_fds_ge_than(int n, int exclude_fd)
 
 		r = close(val);
 		if (r < 0) {
-			debug("cannot close %d: %m", val);
+			debug("cannot close %lld: %m", val);
 			failures++;
 		}
 	}


### PR DESCRIPTION
The debug log in the close_fds_ge_than fallback path uses %d to format val, which is declared as long long (from strtoll). This is undefined behavior per the C standard. In practice /proc/self/fd entries always fit in int so the resulting debug output hasn't been wrong in real deployments, but the format string is still incorrect.

Use %lld to match the type.