### PR TITLE
build: enable stricter format string warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,5 +18,7 @@
 
 bin_PROGRAMS = catatonit
 
+AM_CFLAGS = -Wall -Wformat=2 -Werror=format-security
+
 catatonit_LDFLAGS = -all-static
 catatonit_SOURCES = catatonit.c

--- a/catatonit.c
+++ b/catatonit.c
@@ -52,7 +52,15 @@ static enum loglevel_t {
 	LOG_DEBUG = 4,
 } global_log_level = LOG_ERROR;
 
-static void _log(enum loglevel_t level, char *fmt, ...)
+#if defined(__GNUC__) || defined(__clang__)
+# define PRINTF_LIKE(fmt_idx, arg_idx) __attribute__((format(printf, fmt_idx, arg_idx)))
+#else
+# define PRINTF_LIKE(fmt_idx, arg_idx)
+#endif
+
+static void _log(enum loglevel_t level, const char *fmt, ...) PRINTF_LIKE(2, 3);
+
+static void _log(enum loglevel_t level, const char *fmt, ...)
 {
 	va_list ap;
 	int old_errno = errno;


### PR DESCRIPTION
Add compiler warning flags for format-string issues in Makefile.am and annotate the internal logging helper as printf-like so those checks apply through the fatal/error/warn macros.

Verified with a Linux build by running ./autogen.sh, ./configure, and make V=1 successfully.